### PR TITLE
fix: exit when the connection to kubernetes hangs up

### DIFF
--- a/lib/runtime/runtime.go
+++ b/lib/runtime/runtime.go
@@ -72,7 +72,7 @@ func EventBuffer(context context.Context, client k.Interface,
 							metrics.TotalEventOps.Inc()
 						} else {
 							// the channel got closed, so we need to restart
-							log.Error("Kubernetes hung up on us, restarting event watcher")
+							log.Error("Kubernetes hung up on us, exiting!")
 							os.Exit(1)
 						}
 						//case <-time.After(30 * time.Minute):

--- a/lib/runtime/runtime.go
+++ b/lib/runtime/runtime.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	k "k8s.io/client-go/kubernetes"
+	"os"
 	"sync"
 	"time"
 )
@@ -60,7 +61,6 @@ func EventBuffer(context context.Context, client k.Interface,
 					select {
 					case update, hasUpdate := <-c:
 						if hasUpdate {
-
 							err := registry.OnEvent(subscription.Message{
 								Event:  update,
 								Client: client,
@@ -70,10 +70,10 @@ func EventBuffer(context context.Context, client k.Interface,
 								return err
 							}
 							metrics.TotalEventOps.Inc()
-						}
-						if !hasUpdate {
+						} else {
 							// the channel got closed, so we need to restart
 							log.Error("Kubernetes hung up on us, restarting event watcher")
+							os.Exit(1)
 						}
 						//case <-time.After(30 * time.Minute):
 						//	// deal with the issue where we get no events


### PR DESCRIPTION
# Issue
## Summary
When the connection to k8s hangs up we simply log an error without exiting thus no restart

## Description



# Fix
exit when the connection to Kubernetes hangs up


@ardoq/devops