### PR TITLE
(feat) migrate from repeated fields to shared components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ unit-tests: $(SOURCES) get-ginkgo
 ## Runs all tests
 all-tests: $(SOURCES) unit-tests ardoq-integration-tests k8s-integration-tests
 
-up:
+kind-up:
 	kind create cluster --name=kind
 
-down:
+kind-down:
 	kind delete cluster --name=kind
 
 docker-build:

--- a/bootstrap_fields.yaml
+++ b/bootstrap_fields.yaml
@@ -10,9 +10,6 @@
 - label: "Node Allocatable Storage"
   type: Text
   componentType: [ "Node" ]
-- label: "Node Architecture"
-  type: Text
-  componentType: [ "Node" ]
 - label: "Node Capacity CPU"
   type: Number
   componentType: [ "Node" ]
@@ -31,9 +28,6 @@
 - label: "Node Creation Timestamp"
   type: DateTime
   componentType: [ "Node" ]
-- label: "Node Instance Type"
-  type: Text
-  componentType: [ "Node" ]
 - label: "Node Kernel Version"
   type: Text
   componentType: [ "Node" ]
@@ -46,19 +40,7 @@
 - label: "Node OS Image"
   type: Text
   componentType: [ "Node" ]
-- label: "Node OS"
-  type: Text
-  componentType: [ "Node" ]
-- label: "Node Pool"
-  type: Text
-  componentType: [ "Node" ]
 - label: "Node Provider"
-  type: Text
-  componentType: [ "Node" ]
-- label: "Node Region"
-  type: Text
-  componentType: [ "Node" ]
-- label: "Node Zone"
   type: Text
   componentType: [ "Node" ]
 - label: "Resource Creation Timestamp"
@@ -67,18 +49,9 @@
 - label: "Resource Image"
   type: Text
   componentType: [ "Deployment","StatefulSet" ]
-- label: "Resource Project"
-  type: Text
-  componentType: [ "Deployment","StatefulSet" ]
 - label: "Resource Replicas"
   type: Text
   componentType: [ "Deployment","StatefulSet" ]
-- label: "Resource Stack"
-  type: Text
-  componentType: [ "Deployment","StatefulSet" ]
-- label: "Resource Team"
-  type: Text
-  componentType: ["Deployment", "StatefulSet"]
 - label: "Resource Requests CPU"
   type: Number
   componentType: ["Deployment", "StatefulSet"]
@@ -91,3 +64,6 @@
 - label: "Resource Limits Memory"
   type: Text
   componentType: ["Deployment", "StatefulSet"]
+- label: "Shared Category"
+  type: Text
+  componentType: ["SharedNodeComponent","SharedResourceComponent"]

--- a/bootstrap_models.yaml
+++ b/bootstrap_models.yaml
@@ -35,7 +35,7 @@ root:
             icon: "wrench"
             returnsValue: true
             level: 3
-            children: {}
+            children: { }
       p12:
         name: Node
         id: "p12"
@@ -49,4 +49,4 @@ root:
             icon: "wrench"
             returnsValue: true
             level: 3
-            children: {}
+            children: { }

--- a/bootstrap_models.yaml
+++ b/bootstrap_models.yaml
@@ -29,10 +29,24 @@ root:
             returnsValue: true
             level: 3
             children: { }
+          p119:
+            name: AppResCommon
+            id: "p119"
+            icon: "wrench"
+            returnsValue: true
+            level: 3
+            children: {}
       p12:
         name: Node
         id: "p12"
         icon: "server"
         returnsValue: true
         level: 2
-        children: { }
+        children:
+          p129:
+            name: NodeCommon
+            id: "p129"
+            icon: "wrench"
+            returnsValue: true
+            level: 3
+            children: {}

--- a/bootstrap_models.yaml
+++ b/bootstrap_models.yaml
@@ -30,7 +30,7 @@ root:
             level: 3
             children: { }
           p119:
-            name: AppResCommon
+            name: SharedResourceComponent
             id: "p119"
             icon: "wrench"
             returnsValue: true
@@ -44,7 +44,7 @@ root:
         level: 2
         children:
           p129:
-            name: NodeCommon
+            name: SharedNodeComponent
             id: "p129"
             icon: "wrench"
             returnsValue: true

--- a/controllers/ardoqcontroller.go
+++ b/controllers/ardoqcontroller.go
@@ -16,7 +16,7 @@ var (
 	org                           = os.Getenv("ARDOQ_ORG")
 	workspaceId                   = os.Getenv("ARDOQ_WORKSPACE_ID")
 	validApplicationResourceTypes = []string{"Deployment", "StatefulSet"}
-	ApplicationLinks              = []string{"RUNS_ON", "OWNED_BY", "SUPPORTED_BY"}
+	ApplicationLinks              = []string{"Owns", "Is realized By", "Is Supported By"}
 	NodeLinks                     = []string{"LOCATION", "SUB_LOCATION", "ARCHITECTURE", "INSTANCE_TYPE", "OS", "NODE_POOL"}
 )
 
@@ -114,9 +114,9 @@ func GenericUpsert(resourceType string, genericResource interface{}) string {
 		case "Deployment", "StatefulSet":
 			resource.ID = componentId
 			PersistToCache("ResourceType/"+resource.Namespace+"/"+resourceType+"/"+name, resource)
-			resource.Link("OWNED_BY", GenericUpsertSharedComponents("Resource", "team", resource.Team))
-			resource.Link("RUNS_ON", GenericUpsertSharedComponents("Resource", "stack", resource.Stack))
-			resource.Link("SUPPORTED_BY", GenericUpsertSharedComponents("Resource", "project", resource.Project))
+			resource.Link("Owns", GenericUpsertSharedComponents("Resource", "team", resource.Team), true)
+			resource.Link("Is realized By", GenericUpsertSharedComponents("Resource", "stack", resource.Stack))
+			resource.Link("Is Supported By", GenericUpsertSharedComponents("Resource", "project", resource.Project))
 			break
 		case "Node":
 			node.ID = componentId
@@ -145,9 +145,9 @@ func GenericUpsert(resourceType string, genericResource interface{}) string {
 			return componentId
 		}
 		PersistToCache("ResourceType/"+resource.Namespace+"/"+resourceType+"/"+name, resource)
-		resource.Link("OWNED_BY", GenericUpsertSharedComponents("Resource", "team", resource.Team))
-		resource.Link("RUNS_ON", GenericUpsertSharedComponents("Resource", "stack", resource.Stack))
-		resource.Link("SUPPORTED_BY", GenericUpsertSharedComponents("Resource", "project", resource.Project))
+		resource.Link("Owns", GenericUpsertSharedComponents("Resource", "team", resource.Team), true)
+		resource.Link("Is realized By", GenericUpsertSharedComponents("Resource", "stack", resource.Stack))
+		resource.Link("Is Supported By", GenericUpsertSharedComponents("Resource", "project", resource.Project))
 		break
 	case "Node":
 		node.ID = componentId

--- a/controllers/ardoqcontroller.go
+++ b/controllers/ardoqcontroller.go
@@ -16,6 +16,8 @@ var (
 	org                           = os.Getenv("ARDOQ_ORG")
 	workspaceId                   = os.Getenv("ARDOQ_WORKSPACE_ID")
 	validApplicationResourceTypes = []string{"Deployment", "StatefulSet"}
+	ApplicationLinks              = []string{"RUNS_ON", "OWNED_BY", "SUPPORTED_BY"}
+	NodeLinks                     = []string{"LOCATION", "SUB_LOCATION", "ARCHITECTURE", "INSTANCE_TYPE", "OS", "NODE_POOL"}
 )
 
 func GenericUpsert(resourceType string, genericResource interface{}) string {
@@ -66,9 +68,6 @@ func GenericUpsert(resourceType string, genericResource interface{}) string {
 			"resource_image":              resource.Image,
 			"resource_replicas":           resource.Replicas,
 			"resource_creation_timestamp": resource.CreationTimestamp,
-			"resource_stack":              resource.Stack,
-			"resource_team":               resource.Team,
-			"resource_project":            resource.Project,
 			"resource_requests_cpu":       resource.Requests.CPU,
 			"resource_requests_memory":    resource.Requests.Memory,
 			"resource_limits_cpu":         resource.Limits.CPU,
@@ -79,13 +78,10 @@ func GenericUpsert(resourceType string, genericResource interface{}) string {
 	case "Node":
 		component.Parent = LookupCluster(os.Getenv("ARDOQ_CLUSTER"))
 		component.Fields = map[string]interface{}{
-			"node_architecture":        node.Architecture,
 			"node_container_runtime":   node.ContainerRuntime,
-			"node_instance_type":       node.InstanceType,
 			"node_kernel_version":      node.KernelVersion,
 			"node_kubelet_version":     node.KubeletVersion,
 			"node_kube_proxy_version":  node.KubeProxyVersion,
-			"node_os":                  node.OperatingSystem,
 			"node_os_image":            node.OSImage,
 			"node_capacity_cpu":        node.Capacity.CPU,
 			"node_capacity_memory":     node.Capacity.Memory,
@@ -95,11 +91,8 @@ func GenericUpsert(resourceType string, genericResource interface{}) string {
 			"node_allocatable_memory":  node.Allocatable.Memory,
 			"node_allocatable_storage": node.Allocatable.Storage,
 			"node_allocatable_pods":    node.Allocatable.Pods,
-			"node_pool":                node.Pool,
 			"node_provider":            node.Provider,
 			"node_creation_timestamp":  node.CreationTimestamp,
-			"node_zone":                node.Zone,
-			"node_region":              node.Region,
 		}
 		componentId = LookupNode(name)
 		break
@@ -121,10 +114,19 @@ func GenericUpsert(resourceType string, genericResource interface{}) string {
 		case "Deployment", "StatefulSet":
 			resource.ID = componentId
 			PersistToCache("ResourceType/"+resource.Namespace+"/"+resourceType+"/"+name, resource)
+			resource.Link("OWNED_BY", GenericUpsertSharedComponents("Resource", "team", resource.Team))
+			resource.Link("RUNS_ON", GenericUpsertSharedComponents("Resource", "stack", resource.Stack))
+			resource.Link("SUPPORTED_BY", GenericUpsertSharedComponents("Resource", "project", resource.Project))
 			break
 		case "Node":
 			node.ID = componentId
 			PersistToCache("ResourceType/"+resourceType+"/"+name, node)
+			node.Link("LOCATION", GenericUpsertSharedComponents("Node", "location", node.Region))
+			node.Link("SUB_LOCATION", GenericUpsertSharedComponents("Node", "sub_location", node.Zone))
+			node.Link("ARCHITECTURE", GenericUpsertSharedComponents("Node", "architecture", node.Architecture))
+			node.Link("INSTANCE_TYPE", GenericUpsertSharedComponents("Node", "instance_type", node.InstanceType))
+			node.Link("OS", GenericUpsertSharedComponents("Node", "node_os", node.OperatingSystem))
+			node.Link("NODE_POOL", GenericUpsertSharedComponents("Node", "node_pool", node.Pool))
 			break
 		}
 		log.Infof("Added %s: %s: %s", resourceType, component.Name, componentId)
@@ -143,6 +145,9 @@ func GenericUpsert(resourceType string, genericResource interface{}) string {
 			return componentId
 		}
 		PersistToCache("ResourceType/"+resource.Namespace+"/"+resourceType+"/"+name, resource)
+		resource.Link("OWNED_BY", GenericUpsertSharedComponents("Resource", "team", resource.Team))
+		resource.Link("RUNS_ON", GenericUpsertSharedComponents("Resource", "stack", resource.Stack))
+		resource.Link("SUPPORTED_BY", GenericUpsertSharedComponents("Resource", "project", resource.Project))
 		break
 	case "Node":
 		node.ID = componentId
@@ -150,6 +155,12 @@ func GenericUpsert(resourceType string, genericResource interface{}) string {
 			return componentId
 		}
 		PersistToCache("ResourceType/"+resourceType+"/"+name, node)
+		node.Link("LOCATION", GenericUpsertSharedComponents("Node", "location", node.Region))
+		node.Link("SUB_LOCATION", GenericUpsertSharedComponents("Node", "sub_location", node.Zone))
+		node.Link("ARCHITECTURE", GenericUpsertSharedComponents("Node", "architecture", node.Architecture))
+		node.Link("INSTANCE_TYPE", GenericUpsertSharedComponents("Node", "instance_type", node.InstanceType))
+		node.Link("OS", GenericUpsertSharedComponents("Node", "node_os", node.OperatingSystem))
+		node.Link("NODE_POOL", GenericUpsertSharedComponents("Node", "node_pool", node.Pool))
 		break
 	}
 	requestStarted := time.Now()

--- a/controllers/bootstrapcontroller.go
+++ b/controllers/bootstrapcontroller.go
@@ -176,7 +176,7 @@ func InitializeCache() error {
 		}
 	}
 	for _, v := range *components {
-		if Contains([]string{"SharedResourceComponent", "SharedNodeComponent"}, v.Type) {
+		if Contains([]string{"SharedResourceComponent", "SharedNodeComponent"}, v.Type) && v.Parent == clusterComponent.ID {
 			PersistToCache(v.Type+"/"+v.Fields["shared_category"].(string)+"/"+strings.ToLower(v.Name), v.ID)
 		}
 	}

--- a/controllers/bootstrapcontroller.go
+++ b/controllers/bootstrapcontroller.go
@@ -191,10 +191,10 @@ func InitializeCache() error {
 	metrics.RequestStatusCode.WithLabelValues("success").Inc()
 	for _, v := range *references {
 		if Contains(ApplicationLinks, v.DisplayText) && v.RootWorkspace == workspaceId {
-			PersistToCache("SharedResourceLinks/"+v.Source+"/"+v.Target, v.ID)
+			PersistToCache("SharedResourceLinks/"+v.Description, v.ID)
 		}
 		if Contains(NodeLinks, v.DisplayText) && v.RootWorkspace == workspaceId {
-			PersistToCache("SharedNodeLinks/"+v.Source+"/"+v.Target, v.ID)
+			PersistToCache("SharedNodeLinks/"+v.Description, v.ID)
 		}
 	}
 	return nil

--- a/controllers/bootstrapcontroller.go
+++ b/controllers/bootstrapcontroller.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -131,9 +132,8 @@ func InitializeCache() error {
 		if v.Type == "Node" && v.Parent == clusterComponent.ID {
 			nodeComponents = append(nodeComponents, v)
 			node := Node{
-				ID:           v.ID,
-				Name:         v.Name,
-				Architecture: v.Fields["node_architecture"].(string),
+				ID:   v.ID,
+				Name: v.Name,
 				Capacity: NodeResources{
 					CPU:     int64(v.Fields["node_capacity_cpu"].(float64)),
 					Memory:  v.Fields["node_capacity_memory"].(string),
@@ -150,12 +150,9 @@ func InitializeCache() error {
 				KernelVersion:     v.Fields["node_kernel_version"].(string),
 				KubeletVersion:    v.Fields["node_kubelet_version"].(string),
 				KubeProxyVersion:  v.Fields["node_kube_proxy_version"].(string),
-				OperatingSystem:   v.Fields["node_os"].(string),
 				OSImage:           v.Fields["node_os_image"].(string),
 				Provider:          v.Fields["node_provider"].(string),
 				CreationTimestamp: v.Fields["node_creation_timestamp"].(string),
-				Region:            v.Fields["node_zone"].(string),
-				Zone:              v.Fields["node_region"].(string),
 			}
 			PersistToCache("ResourceType/"+v.Type+"/"+v.Name, node)
 		}
@@ -171,9 +168,6 @@ func InitializeCache() error {
 				Namespace:         getNamespace(namespaceComponents, v.Parent.(string)),
 				Image:             v.Fields["resource_image"].(string),
 				CreationTimestamp: v.Fields["resource_creation_timestamp"].(string),
-				Stack:             v.Fields["resource_stack"].(string),
-				Team:              v.Fields["resource_team"].(string),
-				Project:           v.Fields["resource_project"].(string),
 			}
 			if i, err := strconv.ParseInt(v.Fields["resource_replicas"].(string), 10, 32); err == nil {
 				resource.Replicas = int32(i)

--- a/controllers/bootstrapcontroller.go
+++ b/controllers/bootstrapcontroller.go
@@ -175,6 +175,7 @@ func InitializeCache() error {
 			PersistToCache("ResourceType/"+resource.Namespace+"/"+v.Type+"/"+v.Name, resource)
 		}
 	}
+	//get shared components
 	for _, v := range *components {
 		if Contains([]string{"SharedResourceComponent", "SharedNodeComponent"}, v.Type) {
 			PersistToCache(v.Type+"/"+v.Fields["shared_category"].(string)+"/"+strings.ToLower(v.Name), v.ID)
@@ -189,6 +190,7 @@ func InitializeCache() error {
 		return err
 	}
 	metrics.RequestStatusCode.WithLabelValues("success").Inc()
+	//get shared references
 	for _, v := range *references {
 		if Contains(ApplicationLinks, v.DisplayText) && v.RootWorkspace == workspaceId {
 			PersistToCache("SharedResourceLinks/"+v.Description, v.ID)

--- a/controllers/bootstrapcontroller.go
+++ b/controllers/bootstrapcontroller.go
@@ -176,7 +176,7 @@ func InitializeCache() error {
 		}
 	}
 	for _, v := range *components {
-		if Contains([]string{"SharedResourceComponent", "SharedNodeComponent"}, v.Type) && v.Parent == clusterComponent.ID {
+		if Contains([]string{"SharedResourceComponent", "SharedNodeComponent"}, v.Type) {
 			PersistToCache(v.Type+"/"+v.Fields["shared_category"].(string)+"/"+strings.ToLower(v.Name), v.ID)
 		}
 	}

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -168,3 +168,39 @@ func ParseToMB(val int64) string {
 	}
 	return ""
 }
+func (r *Resource) Link(linkType string, target string) (string, error) {
+	reference, err := ardRestClient().References().Create(context.TODO(),
+		ardoq.ReferenceRequest{
+			Description:     linkType,
+			DisplayText:     linkType,
+			RootWorkspace:   workspaceId,
+			Source:          r.ID,
+			Target:          target,
+			TargetWorkspace: workspaceId,
+			Type:            2,
+		})
+	if err != nil {
+		metrics.RequestStatusCode.WithLabelValues("error").Inc()
+		log.Errorf("Error getting model: %s", err)
+		return "", err
+	}
+	return reference.ID, nil
+}
+func (n *Node) Link(linkType string, target string) (string, error) {
+	reference, err := ardRestClient().References().Create(context.TODO(),
+		ardoq.ReferenceRequest{
+			Description:     linkType,
+			DisplayText:     linkType,
+			RootWorkspace:   workspaceId,
+			Source:          n.ID,
+			Target:          target,
+			TargetWorkspace: workspaceId,
+			Type:            2,
+		})
+	if err != nil {
+		metrics.RequestStatusCode.WithLabelValues("error").Inc()
+		log.Errorf("Error getting model: %s", err)
+		return "", err
+	}
+	return reference.ID, nil
+}

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -183,6 +183,7 @@ func GenericUpsertSharedComponents(resourceType string, category string, name st
 		Name:          strings.ToLower(name),
 		RootWorkspace: workspaceId,
 		TypeID:        lookUpTypeId("Shared" + resourceType + "Component"),
+		Parent:        LookupCluster(os.Getenv("ARDOQ_CLUSTER")),
 		Fields: map[string]interface{}{
 			"shared_category": category,
 		},

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -183,7 +183,6 @@ func GenericUpsertSharedComponents(resourceType string, category string, name st
 		Name:          strings.ToLower(name),
 		RootWorkspace: workspaceId,
 		TypeID:        lookUpTypeId("Shared" + resourceType + "Component"),
-		Parent:        LookupCluster(os.Getenv("ARDOQ_CLUSTER")),
 		Fields: map[string]interface{}{
 			"shared_category": category,
 		},

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -207,7 +207,6 @@ func GenericUpsertSharedComponents(resourceType string, category string, name st
 func (r *Resource) Link(linkType string, compId string, reverse ...bool) {
 	if _, found := GetFromCache("SharedResourceLinks/" + r.ID + "/" + compId); !found && compId != "" {
 		referenceLink := ardoq.ReferenceRequest{
-			Description:     linkType,
 			DisplayText:     linkType,
 			RootWorkspace:   workspaceId,
 			TargetWorkspace: workspaceId,
@@ -215,6 +214,7 @@ func (r *Resource) Link(linkType string, compId string, reverse ...bool) {
 			Source:          compId,
 			Target:          r.ID,
 		}
+		referenceLink.Description = r.ID + "/" + compId
 		if !(len(reverse) > 0 && reverse[0]) {
 			referenceLink.Source = r.ID
 			referenceLink.Target = compId
@@ -233,7 +233,6 @@ func (r *Resource) Link(linkType string, compId string, reverse ...bool) {
 func (n *Node) Link(linkType string, compId string, reverse ...bool) {
 	if _, found := GetFromCache("SharedNodeLinks/" + n.ID + "/" + compId); !found && compId != "" {
 		referenceLink := ardoq.ReferenceRequest{
-			Description:     linkType,
 			DisplayText:     linkType,
 			RootWorkspace:   workspaceId,
 			TargetWorkspace: workspaceId,
@@ -241,6 +240,7 @@ func (n *Node) Link(linkType string, compId string, reverse ...bool) {
 			Source:          compId,
 			Target:          n.ID,
 		}
+		referenceLink.Description = n.ID + "/" + compId
 		if !(len(reverse) > 0 && reverse[0]) {
 			referenceLink.Source = n.ID
 			referenceLink.Target = compId
@@ -257,3 +257,9 @@ func (n *Node) Link(linkType string, compId string, reverse ...bool) {
 	}
 
 }
+
+//func parse_link(input string) string {
+//	output := strings.ReplaceAll(input, " ", "_")
+//	output = strings.ToLower(output)
+//	return output
+//}

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -205,48 +205,55 @@ func GenericUpsertSharedComponents(resourceType string, category string, name st
 	}
 	return componentId
 }
-
-func (r *Resource) Link(linkType string, target string) {
-	if _, found := GetFromCache("SharedResourceLinks/" + r.ID + "/" + target); !found && target != "" {
-		reference, err := ardRestClient().References().Create(context.TODO(),
-			ardoq.ReferenceRequest{
-				Description:     linkType,
-				DisplayText:     linkType,
-				RootWorkspace:   workspaceId,
-				Source:          r.ID,
-				Target:          target,
-				TargetWorkspace: workspaceId,
-				Type:            2,
-			})
+func (r *Resource) Link(linkType string, compId string, reverse ...bool) {
+	if _, found := GetFromCache("SharedResourceLinks/" + r.ID + "/" + compId); !found && compId != "" {
+		referenceLink := ardoq.ReferenceRequest{
+			Description:     linkType,
+			DisplayText:     linkType,
+			RootWorkspace:   workspaceId,
+			TargetWorkspace: workspaceId,
+			Type:            2,
+			Source:          compId,
+			Target:          r.ID,
+		}
+		if !(len(reverse) > 0 && reverse[0]) {
+			referenceLink.Source = r.ID
+			referenceLink.Target = compId
+		}
+		reference, err := ardRestClient().References().Create(context.TODO(), referenceLink)
 		if err != nil {
 			metrics.RequestStatusCode.WithLabelValues("error").Inc()
 			log.Errorf("Error linking resource to a shared component: %s", err)
 		}
 		if reference.ID != "" {
-			PersistToCache("SharedResourceLinks/"+r.ID+"/"+target, reference.ID)
+			PersistToCache("SharedResourceLinks/"+r.ID+"/"+compId, reference.ID)
 		}
 	}
 
 }
-func (n *Node) Link(linkType string, target string) {
-	if _, found := GetFromCache("SharedNodeLinks/" + n.ID + "/" + target); !found && target != "" {
-		reference, err := ardRestClient().References().Create(context.TODO(),
-			ardoq.ReferenceRequest{
-				Description:     linkType,
-				DisplayText:     linkType,
-				RootWorkspace:   workspaceId,
-				Source:          n.ID,
-				Target:          target,
-				TargetWorkspace: workspaceId,
-				Type:            2,
-			})
+func (n *Node) Link(linkType string, compId string, reverse ...bool) {
+	if _, found := GetFromCache("SharedNodeLinks/" + n.ID + "/" + compId); !found && compId != "" {
+		referenceLink := ardoq.ReferenceRequest{
+			Description:     linkType,
+			DisplayText:     linkType,
+			RootWorkspace:   workspaceId,
+			TargetWorkspace: workspaceId,
+			Type:            2,
+			Source:          compId,
+			Target:          n.ID,
+		}
+		if !(len(reverse) > 0 && reverse[0]) {
+			referenceLink.Source = n.ID
+			referenceLink.Target = compId
+		}
+		reference, err := ardRestClient().References().Create(context.TODO(), referenceLink)
 		if err != nil {
 			metrics.RequestStatusCode.WithLabelValues("error").Inc()
 			log.Errorf("Error linking node to a shared component: %s", err)
 
 		}
 		if reference.ID != "" {
-			PersistToCache("SharedNodeLinks/"+n.ID+"/"+target, reference.ID)
+			PersistToCache("SharedNodeLinks/"+n.ID+"/"+compId, reference.ID)
 		}
 	}
 

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -1,7 +1,9 @@
 package helper
 
 import (
+	"K8SArdoqBridge/app/controllers"
 	"math/rand"
+	"strings"
 	"time"
 )
 
@@ -17,4 +19,14 @@ func RandomString(n int) string {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(b)
+}
+func CleanupSharedComponents(resourceType string) {
+	controllers.Cache.Flush()
+	_ = controllers.InitializeCache()
+	for k := range controllers.Cache.Items() {
+		if strings.HasPrefix(k, "Shared"+resourceType+"Component") {
+			s := strings.Split(k, "/")
+			_ = controllers.GenericDeleteSharedComponents(resourceType, s[1], s[2])
+		}
+	}
 }

--- a/tests/integrations/ardoq/application_resources_test.go
+++ b/tests/integrations/ardoq/application_resources_test.go
@@ -5,7 +5,9 @@ import (
 	"K8SArdoqBridge/app/tests/helper"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
 	"time"
 )
 
@@ -54,23 +56,63 @@ var _ = Describe("Deployments", Ordered, func() {
 		})
 	})
 	Context("Deployment Ardoq Bridge tests", Ordered, func() {
+		var compId string
 		BeforeAll(func() {
 			controllers.GenericUpsert("Namespace", namespace)
 		})
 		AfterAll(func() {
 			err := controllers.GenericDelete("Namespace", namespace)
 			Expect(err).ShouldNot(HaveOccurred())
-			if err != nil {
-				return
-			}
+
+			_ = controllers.GenericDeleteSharedComponents("Resource", "team", deploy.Team)
+			_ = controllers.GenericDeleteSharedComponents("Resource", "stack", deploy.Stack)
+			_ = controllers.GenericDeleteSharedComponents("Resource", "project", deploy.Project)
+			log.Info("Cleaned up shared deployment components")
+
 		})
 		It("Can create Deployment", func() {
-			deploy.ID = controllers.GenericUpsert("Deployment", *deploy)
-			Expect(deploy.ID).ShouldNot(BeNil())
+			compId = controllers.GenericUpsert("Deployment", *deploy)
+			Expect(compId).ShouldNot(BeNil())
 		})
 		It("Can Update Deployment", func() {
 			deploy.Replicas += 1
 			Expect(controllers.GenericUpsert("Deployment", *deploy)).ShouldNot(BeNil())
+		})
+		It("Shared deployment components created", func() {
+			controllers.Cache.Flush()
+			err := controllers.InitializeCache()
+			if err != nil {
+				log.Fatalf("Error rebuilding cache: %s", err.Error())
+			}
+			cachedResource, found := controllers.Cache.Get("SharedResourceComponent/team/" + strings.ToLower(deploy.Team))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
+
+			cachedResource, found = controllers.Cache.Get("SharedResourceComponent/project/" + strings.ToLower(deploy.Project))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
+
+			cachedResource, found = controllers.Cache.Get("SharedResourceComponent/stack/" + strings.ToLower(deploy.Stack))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
+		})
+		It("Shared deployment components links created", func() {
+			controllers.Cache.Flush()
+			err := controllers.InitializeCache()
+			if err != nil {
+				log.Fatalf("Error rebuilding cache: %s", err.Error())
+			}
+			cachedResource, found := controllers.Cache.Get("SharedResourceLinks/" + compId + "/" + controllers.GenericUpsertSharedComponents("Resource", "team", deploy.Team))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
+
+			cachedResource, found = controllers.Cache.Get("SharedResourceLinks/" + compId + "/" + controllers.GenericUpsertSharedComponents("Resource", "project", deploy.Project))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
+
+			cachedResource, found = controllers.Cache.Get("SharedResourceLinks/" + compId + "/" + controllers.GenericUpsertSharedComponents("Resource", "stack", deploy.Stack))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
 		})
 		It("Can Delete Deployment", func() {
 			Expect(controllers.GenericDelete("Deployment", *deploy)).Should(BeNil())
@@ -127,19 +169,58 @@ var _ = Describe("StatefulSets", Ordered, func() {
 		})
 	})
 	Context("StatefulSet Ardoq Bridge tests", Ordered, func() {
+		var compId string
 		BeforeAll(func() {
 			controllers.GenericUpsert("Namespace", namespace)
 		})
 		AfterAll(func() {
 			err := controllers.GenericDelete("Namespace", namespace)
 			Expect(err).ShouldNot(HaveOccurred())
-			if err != nil {
-				return
-			}
+
+			_ = controllers.GenericDeleteSharedComponents("Resource", "team", sts.Team)
+			_ = controllers.GenericDeleteSharedComponents("Resource", "stack", sts.Stack)
+			_ = controllers.GenericDeleteSharedComponents("Resource", "project", sts.Project)
+			log.Info("Cleaned up shared deployment components")
 		})
 		It("Can create StatefulSet", func() {
-			sts.ID = controllers.GenericUpsert("StatefulSet", *sts)
-			Expect(sts.ID).ShouldNot(BeNil())
+			compId = controllers.GenericUpsert("StatefulSet", *sts)
+			Expect(compId).ShouldNot(BeNil())
+		})
+		It("Shared deployment components created", func() {
+			controllers.Cache.Flush()
+			err := controllers.InitializeCache()
+			if err != nil {
+				log.Fatalf("Error rebuilding cache: %s", err.Error())
+			}
+			cachedResource, found := controllers.Cache.Get("SharedResourceComponent/team/" + strings.ToLower(sts.Team))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
+
+			cachedResource, found = controllers.Cache.Get("SharedResourceComponent/project/" + strings.ToLower(sts.Project))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
+
+			cachedResource, found = controllers.Cache.Get("SharedResourceComponent/stack/" + strings.ToLower(sts.Stack))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
+		})
+		It("Shared deployment components links created", func() {
+			controllers.Cache.Flush()
+			err := controllers.InitializeCache()
+			if err != nil {
+				log.Fatalf("Error rebuilding cache: %s", err.Error())
+			}
+			cachedResource, found := controllers.Cache.Get("SharedResourceLinks/" + compId + "/" + controllers.GenericUpsertSharedComponents("Resource", "team", sts.Team))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
+
+			cachedResource, found = controllers.Cache.Get("SharedResourceLinks/" + compId + "/" + controllers.GenericUpsertSharedComponents("Resource", "project", sts.Project))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
+
+			cachedResource, found = controllers.Cache.Get("SharedResourceLinks/" + compId + "/" + controllers.GenericUpsertSharedComponents("Resource", "stack", sts.Stack))
+			Expect(cachedResource).ShouldNot(BeNil())
+			Expect(found).Should(BeTrue())
 		})
 		It("Can Update StatefulSet", func() {
 			sts.Replicas += 1

--- a/tests/integrations/ardoq/application_resources_test.go
+++ b/tests/integrations/ardoq/application_resources_test.go
@@ -64,9 +64,7 @@ var _ = Describe("Deployments", Ordered, func() {
 			err := controllers.GenericDelete("Namespace", namespace)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_ = controllers.GenericDeleteSharedComponents("Resource", "team", deploy.Team)
-			_ = controllers.GenericDeleteSharedComponents("Resource", "stack", deploy.Stack)
-			_ = controllers.GenericDeleteSharedComponents("Resource", "project", deploy.Project)
+			helper.CleanupSharedComponents("Resource")
 			log.Info("Cleaned up shared deployment components")
 
 		})
@@ -177,9 +175,7 @@ var _ = Describe("StatefulSets", Ordered, func() {
 			err := controllers.GenericDelete("Namespace", namespace)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_ = controllers.GenericDeleteSharedComponents("Resource", "team", sts.Team)
-			_ = controllers.GenericDeleteSharedComponents("Resource", "stack", sts.Stack)
-			_ = controllers.GenericDeleteSharedComponents("Resource", "project", sts.Project)
+			helper.CleanupSharedComponents("Resource")
 			log.Info("Cleaned up shared deployment components")
 		})
 		It("Can create StatefulSet", func() {

--- a/tests/integrations/ardoq/ardoq_suite_test.go
+++ b/tests/integrations/ardoq/ardoq_suite_test.go
@@ -27,10 +27,16 @@ var _ = BeforeSuite(func() {
 		log.Error(err)
 	}
 	log.Infof("Cluster to be used: %s", tempClusterName)
+	controllers.Cache.Flush()
+	err = controllers.InitializeCache()
+	if err != nil {
+		log.Fatalf("Error building cache: %s", err.Error())
+	}
 	log.Info("Initializing Complete")
 })
 
 var _ = AfterSuite(func() {
 	_ = controllers.GenericDelete("Cluster", tempClusterName)
+	controllers.Cache.Flush()
 	log.Info("Cleanup Complete...Terminating!!")
 })

--- a/tests/integrations/ardoq/nodes_test.go
+++ b/tests/integrations/ardoq/nodes_test.go
@@ -88,8 +88,7 @@ var _ = Describe("Nodes", Ordered, func() {
 	Context("Node to Ardoq Integration tests", Ordered, func() {
 		var compId string
 		AfterAll(func() {
-			_ = controllers.GenericDeleteSharedComponents("Node", "node_os", node.OperatingSystem)
-			_ = controllers.GenericDeleteSharedComponents("Node", "architecture", node.Architecture)
+			helper.CleanupSharedComponents("Node")
 			log.Info("Cleaned up shared node components")
 		})
 		It("Can create Node", func() {

--- a/tests/integrations/k8s/bootstrap_fields.yaml
+++ b/tests/integrations/k8s/bootstrap_fields.yaml
@@ -10,9 +10,6 @@
 - label: "Node Allocatable Storage"
   type: Text
   componentType: [ "Node" ]
-- label: "Node Architecture"
-  type: Text
-  componentType: [ "Node" ]
 - label: "Node Capacity CPU"
   type: Number
   componentType: [ "Node" ]
@@ -31,9 +28,6 @@
 - label: "Node Creation Timestamp"
   type: DateTime
   componentType: [ "Node" ]
-- label: "Node Instance Type"
-  type: Text
-  componentType: [ "Node" ]
 - label: "Node Kernel Version"
   type: Text
   componentType: [ "Node" ]
@@ -46,19 +40,7 @@
 - label: "Node OS Image"
   type: Text
   componentType: [ "Node" ]
-- label: "Node OS"
-  type: Text
-  componentType: [ "Node" ]
-- label: "Node Pool"
-  type: Text
-  componentType: [ "Node" ]
 - label: "Node Provider"
-  type: Text
-  componentType: [ "Node" ]
-- label: "Node Region"
-  type: Text
-  componentType: [ "Node" ]
-- label: "Node Zone"
   type: Text
   componentType: [ "Node" ]
 - label: "Resource Creation Timestamp"
@@ -67,18 +49,9 @@
 - label: "Resource Image"
   type: Text
   componentType: [ "Deployment","StatefulSet" ]
-- label: "Resource Project"
-  type: Text
-  componentType: [ "Deployment","StatefulSet" ]
 - label: "Resource Replicas"
   type: Text
   componentType: [ "Deployment","StatefulSet" ]
-- label: "Resource Stack"
-  type: Text
-  componentType: [ "Deployment","StatefulSet" ]
-- label: "Resource Team"
-  type: Text
-  componentType: ["Deployment", "StatefulSet"]
 - label: "Resource Requests CPU"
   type: Number
   componentType: ["Deployment", "StatefulSet"]
@@ -91,3 +64,6 @@
 - label: "Resource Limits Memory"
   type: Text
   componentType: ["Deployment", "StatefulSet"]
+- label: "Shared Category"
+  type: Text
+  componentType: ["SharedNodeComponent","SharedResourceComponent"]

--- a/tests/integrations/k8s/bootstrap_models.yaml
+++ b/tests/integrations/k8s/bootstrap_models.yaml
@@ -29,10 +29,24 @@ root:
             returnsValue: true
             level: 3
             children: { }
+          p119:
+            name: SharedResourceComponent
+            id: "p119"
+            icon: "wrench"
+            returnsValue: true
+            level: 3
+            children: { }
       p12:
         name: Node
         id: "p12"
         icon: "server"
         returnsValue: true
         level: 2
-        children: { }
+        children:
+          p129:
+            name: SharedNodeComponent
+            id: "p129"
+            icon: "wrench"
+            returnsValue: true
+            level: 3
+            children: { }

--- a/tests/integrations/k8s/k8s_suite_test.go
+++ b/tests/integrations/k8s/k8s_suite_test.go
@@ -56,10 +56,15 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	log.Info("Cleanup")
+	//Cleanup shared components
+	helper.CleanupSharedComponents("Resource")
+	helper.CleanupSharedComponents("Node")
+
 	//cleanup cluster in ardoq
 	cleanupCluster()
-	//cleanup running binary
+	//kill the running session
 	session.Kill()
+	//cleanup running binary
 	gexec.CleanupBuildArtifacts()
 	log.Info("Cleanup Complete...Terminating!!")
 })


### PR DESCRIPTION
# Issue
## Summary
There are a number of repeated fields on both the nodes and application resources. 

## Description
Attributes like Node OS, Architecture etc. are common amongst multiple nodes and clusters, to avoid deduplication we can create them as components instead.
Same issue on Application Resources

# Fix
- modify the model to include the shared components
- move shared attributes from fields to components

@ardoq/devops