### PR TITLE
(fix) gracefully handle kubernetes hangups

### DIFF
--- a/lib/runtime/runtime.go
+++ b/lib/runtime/runtime.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	k "k8s.io/client-go/kubernetes"
-	"os"
 	"sync"
 	"time"
 )
@@ -57,6 +56,7 @@ func EventBuffer(context context.Context, client k.Interface,
 			err := func(t int, c <-chan watch.Event) error {
 				defer wg.Done()
 				counter := 0
+			loop:
 				for {
 					select {
 					case update, hasUpdate := <-c:
@@ -73,7 +73,8 @@ func EventBuffer(context context.Context, client k.Interface,
 						} else {
 							// the channel got closed, so we need to restart
 							log.Error("Kubernetes hung up on us, exiting!")
-							os.Exit(1)
+							break loop
+							//os.Exit(1)
 						}
 						//case <-time.After(30 * time.Minute):
 						//	// deal with the issue where we get no events
@@ -81,6 +82,7 @@ func EventBuffer(context context.Context, client k.Interface,
 					}
 					counter++
 				}
+				return nil
 			}(x, o)
 			if err != nil {
 				log.Error(err)


### PR DESCRIPTION
# Issue
## Summary
The service restarts when Kubernetes hangs up

## Description



# Fix

this should help to restart the go coroutine instead of the full service

@ardoq/devops