### PR TITLE
Fix deprecated save-state and set-output github actions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           fetch-depth: 0
       - name: Set output
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo "name=tag::${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod

--- a/tests/integrations/k8s/k8s_suite_test.go
+++ b/tests/integrations/k8s/k8s_suite_test.go
@@ -11,6 +11,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func TestK8s(t *testing.T) {

--- a/tests/integrations/k8s/k8s_suite_test.go
+++ b/tests/integrations/k8s/k8s_suite_test.go
@@ -11,9 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 func TestK8s(t *testing.T) {
@@ -44,9 +41,9 @@ var _ = BeforeSuite(func() {
 	session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(session.Err, 5).Should(gbytes.Say(".*Got watcher client.*"))
-	Eventually(session.Err, 20).Should(gbytes.Say(`.*Initialised cluster in Ardoq`))
+	Eventually(session.Err, 30).Should(gbytes.Say(`.*Initialised cluster in Ardoq`))
 	Eventually(session.Err, 10).Should(gbytes.Say(`.*Starting event buffer`))
-	Eventually(session.Err, 20).Should(gbytes.Say(`.*successfully acquired lease.*`))
+	Eventually(session.Err, 30).Should(gbytes.Say(`.*successfully acquired lease.*`))
 	controllers.ApplyDelay(5)
 	log.Info("Initializing Complete")
 })


### PR DESCRIPTION
Signed-off-by: Georgi Ivanov <georgi.ivanov@ardoq.com>

# Issue
Depretiated set-output github action.
## Summary
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Description
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


# Fix


@ardoq/devops